### PR TITLE
Ajout d'un fichier de configuration

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -25,3 +25,4 @@
     rdev = rebase origin/dev
     amend = commit --amend --no-edit
     fixup = commit --fixup
+    please = push --force-with-lease

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,27 @@
+[color]
+    ui = true
+[rebase]
+    autostash = true
+    autosquash = true
+[status]
+    showStash = true
+[core]
+    pager =
+[rerere]
+    enabled = true
+[alias]
+    st = status
+    stashu = stash -u
+    stashpop = stash pop
+    prs = pull --rebase --no-ff --autostash
+    rebase = rebase --no-ff
+    last = log -1 HEAD
+    undo = reset --soft HEAD^
+    ap = add -p
+    co = checkout
+    lg = log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --date=relative 
+    lg10 = !git -P log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --date=relative -10
+    ri = rebase -i origin/dev --autosquash
+    rdev = rebase origin/dev
+    amend = commit --amend --no-edit
+    fixup = commit --fixup

--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@
 9. Gestion des conflits
 10. Le reflog
 11. Discussion
+
+
+## Ajout de la configuration de git:
+```bash
+    git config --local include.path "../.gitconfig"
+```


### PR DESCRIPTION
On peut ajouter le fichier de configuration dans son local via `git config --local include.path "../.gitconfig"`

On peut regarder les options, les différents alias, et aussi regarder dans `.git/config` (voir le `../.gitconfig `ajouté)